### PR TITLE
Add gitbook configuration

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./
+
+structure: 
+  readme: README.md
+  summary: SUMMARY.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,7 +1,10 @@
 # Table of contents
 
-* [📖 Docs](README.md)
-* [🪄 Smart Contracts](contracts/README.md)
-  * [LoyaltyLedger](contracts/LoyaltyLedger.md)
-  * [PassageRegistry](contracts/PassageRegistry.md)
-  * [Passport](contracts/Passport.md)
+- [📖 Docs](README.md)
+- [🪄 Smart Contracts](contracts/README.md)
+  - [LoyaltyLedger](contracts/LoyaltyLedger.md)
+  - [PassageRegistry](contracts/PassageRegistry.md)
+  - [Passport](contracts/Passport.md)
+  - [Depolyed Contracts](contracts/DeployedContracts.md)
+- [📈 Subgraph](Subgraph/README.md)
+  - [Subgraph Endpoints](Subgraph/SubgraphEndpoints.md)

--- a/Subgraph/README.md
+++ b/Subgraph/README.md
@@ -1,0 +1,5 @@
+---
+description: Check out our subgraph documentation!
+---
+
+# 📈 Subgraph


### PR DESCRIPTION
The new pages weren't showing up on gitbook because they were not configured properly in the SUMMARY.md file.

The SUMMARY.md file controls the Table of Contents and should always be updated when new files are created.