### PR TITLE
Rename "Depolyed Contracts" -> "Deployed Contracts"

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,6 @@
   - [LoyaltyLedger](contracts/LoyaltyLedger.md)
   - [PassageRegistry](contracts/PassageRegistry.md)
   - [Passport](contracts/Passport.md)
-  - [Depolyed Contracts](contracts/DeployedContracts.md)
+  - [Deployed Contracts](contracts/DeployedContracts.md)
 - [📈 Subgraph](Subgraph/README.md)
   - [Subgraph Endpoints](Subgraph/SubgraphEndpoints.md)


### PR DESCRIPTION
There was minor typo in the Table of Contents in which "Deployed Contracts" was spelled "Depolyed Contracts".